### PR TITLE
Added deprecation warnings when accessing color enums, fix #8

### DIFF
--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from warnings import warn
-
 __all__ = [
     "color_to_rgb",
     "color_to_rgba",

--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -1,6 +1,7 @@
 """Colors and utility functions for conversion between different color models."""
 
 from __future__ import annotations
+from warnings import warn
 
 __all__ = [
     "color_to_rgb",
@@ -21,7 +22,7 @@ __all__ = [
 ]
 
 import random
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Iterable
 
 import numpy as np
@@ -30,8 +31,88 @@ from colour import Color
 from ..utils.bezier import interpolate
 from ..utils.space_ops import normalize
 
+class ColorsMeta(EnumMeta):
+    def __getattribute__(self, colorName):
+        colors = [
+        'white', 
+        'gray_a', 
+        'gray_b', 
+        'gray_c', 
+        'gray_d', 
+        'gray_e', 
+        'black', 
+        'lighter_gray', 
+        'gray', 
+        'darker_gray', 
+        'blue_a', 
+        'blue_b', 
+        'blue_c', 
+        'blue_d', 
+        'blue_e',
+        'pure_blue',
+        'blue',
+        'dark_blue',
+        'teal_a',
+        'teal_b',
+        'teal_c',
+        'teal_d',
+        'teal_e',
+        'teal',
+        'green_a',
+        'green_b',
+        'green_c',
+        'green_d',
+        'green_e',
+        'pure_green',
+        'green',
+        'yellow_a',
+        'yellow_b',
+        'yellow_c',
+        'yellow_d',
+        'yellow_e',
+        'yellow',
+        'gold_a',
+        'gold_b',
+        'gold_c',
+        'gold_d',
+        'gold_e',
+        'gold',
+        'red_a',
+        'red_b',
+        'red_c',
+        'red_d',
+        'red_e',
+        'pure_red',
+        'red',
+        'maroon_a',
+        'maroon_b',
+        'maroon_c',
+        'maroon_d',
+        'maroon_e',
+        'maroon',
+        'purple_a',
+        'purple_b',
+        'purple_c',
+        'purple_d',
+        'purple_e',
+        'purple',
+        'pink',
+        'light_pink',
+        'orange',
+        'light_brown',
+        'dark_brown',
+        'gray_brown'
+        ]
+        if colorName in colors:
+            warn(
+                "Color enums is deprecated in favor of the constants. "
+                "The constants can be accessed by importing manim.utils.color",
+                DeprecationWarning,
+                stacklevel=2
+            )
+        return EnumMeta.__getattribute__(self, colorName)
 
-class Colors(Enum):
+class Colors(Enum, metaclass=ColorsMeta):
     """A list of pre-defined colors.
 
     Examples


### PR DESCRIPTION
This PR introduces deprecation warnings when using any of the enums in the `Colors` class

Closes #8 
