### PR TITLE
Remove use of deprecated functions across library #4

### DIFF
--- a/manim/mobject/graphing/probability.py
+++ b/manim/mobject/graphing/probability.py
@@ -356,9 +356,9 @@ class BarChart(Axes):
             bar.next_to(self.c2p(i + 0.5, 0), pos, buff=0)
             self.bars.add(bar)
         if isinstance(self.bar_colors, str):
-            self.bars.set_color_by_gradient(self.bar_colors)
+            self.bars.set_color_by_gradient(Color(self.bar_colors))
         else:
-            self.bars.set_color_by_gradient(*self.bar_colors)
+            self.bars.set_color_by_gradient(*[Color(c) for c in self.bar_colors])
 
         self.add_to_back(self.bars)
 

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -1871,7 +1871,7 @@ class OpenGLMobject:
 
     def set_rgba_array(self, color=None, opacity=None, name="rgbas", recurse=True):
         if color is not None:
-            rgbs = np.array([color_to_rgb(c) for c in listify(color)])
+            rgbs = np.array([c.get_rgb() for c in listify(color)])
         if opacity is not None:
             opacities = listify(opacity)
 

--- a/manim/mobject/opengl/opengl_mobject.py
+++ b/manim/mobject/opengl/opengl_mobject.py
@@ -10,7 +10,7 @@ from typing import Iterable, Sequence
 
 import moderngl
 import numpy as np
-from colour import Color
+from colour import Color, rgb2hex
 
 from manim import config
 from manim.constants import *
@@ -1937,7 +1937,7 @@ class OpenGLMobject:
         return self
 
     def get_color(self):
-        return rgb_to_hex(self.rgbas[0, :3])
+        return rgb2hex((self.rgbas[0], self.rgbas[1], self.rgbas[2]))
 
     def get_opacity(self):
         return self.rgbas[0, 3]

--- a/manim/mobject/opengl/opengl_vectorized_mobject.py
+++ b/manim/mobject/opengl/opengl_vectorized_mobject.py
@@ -7,7 +7,7 @@ from typing import Callable, Iterable, Sequence
 
 import moderngl
 import numpy as np
-from colour import Color
+from colour import Color, rgb2hex
 
 from manim import config
 from manim.constants import *
@@ -328,13 +328,13 @@ class OpenGLVMobject(OpenGLMobject):
         return self
 
     def get_fill_colors(self):
-        return [Color(rgb_to_hex(rgba[:3])) for rgba in self.fill_rgba]
+        return [Color(rgb2hex(tuple(rgba[:3]))) for rgba in self.fill_rgba]
 
     def get_fill_opacities(self):
         return self.fill_rgba[:, 3]
 
     def get_stroke_colors(self):
-        return [Color(rgb_to_hex(rgba[:3])) for rgba in self.stroke_rgba]
+        return [Color(rgb2hex(tuple(rgba[:3]))) for rgba in self.stroke_rgba]
 
     def get_stroke_opacities(self):
         return self.stroke_rgba[:, 3]

--- a/manim/mobject/svg/style_utils.py
+++ b/manim/mobject/svg/style_utils.py
@@ -7,9 +7,7 @@ __all__ = ["cascade_element_style", "parse_style", "parse_color_string"]
 
 from xml.dom.minidom import Element as MinidomElement
 
-from colour import web2hex
-
-from ...utils.color import rgb_to_hex
+from colour import rgb2hex, web2hex
 
 CASCADING_STYLING_ATTRIBUTES: list[str] = [
     "fill",
@@ -109,7 +107,7 @@ def parse_color_string(color_spec: str) -> str:
         else:
             parsed_rgbs = [int(i) / 255.0 for i in splits]
 
-        hex_color = rgb_to_hex(parsed_rgbs)
+        hex_color = rgb2hex(tuple(parsed_rgbs))
 
     elif color_spec[0] == "#":
         # its OK, parse as hex color standard.

--- a/manim/mobject/vector_field.py
+++ b/manim/mobject/vector_field.py
@@ -29,7 +29,7 @@ from ..constants import OUT, RIGHT, UP
 from ..mobject.mobject import Mobject
 from ..mobject.types.vectorized_mobject import VGroup, VMobject
 from ..utils.bezier import interpolate, inverse_interpolate
-from ..utils.color import BLUE_E, GREEN, RED, YELLOW, color_to_rgb, rgb_to_color
+from ..utils.color import BLUE_E, GREEN, RED, YELLOW, rgb_to_color
 from ..utils.rate_functions import ease_out_sine, linear
 from ..utils.simple_functions import sigmoid
 
@@ -82,7 +82,7 @@ class VectorField(VGroup):
                     return np.linalg.norm(p)
 
             self.color_scheme = color_scheme  # TODO maybe other default for direction?
-            self.rgbs = np.array(list(map(color_to_rgb, colors)))
+            self.rgbs = np.array([c.get_rgb() for c in colors])
 
             def pos_to_rgb(pos: np.ndarray) -> tuple[float, float, float, float]:
                 vec = self.func(pos)
@@ -410,7 +410,7 @@ class VectorField(VGroup):
         -------
             function to generate the gradients as numpy arrays representing rgba values
         """
-        rgbs = np.array([color_to_rgb(c) for c in colors])
+        rgbs = np.array([c.get_rgb() for c in colors])
 
         def func(values, opacity=1):
             alphas = inverse_interpolate(start, end, np.array(values))


### PR DESCRIPTION
This PR is connected to the changes made in #1.Every use of the deprecated functions are refactored to use `Color` or other equivalent conversion function in `colour` module.   

Closes #4 