### PR TITLE
Changed `warnings` to `@deprecated` in `color.py`, feat #14

### DIFF
--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -538,7 +538,6 @@ __all__ += [
 ]
 
 
-@deprecated(replacement="Color.get_rgb()")
 def color_to_rgb(color: Color | str) -> np.ndarray:
     if isinstance(color, str):
         return hex_to_rgb(color)
@@ -563,12 +562,10 @@ def rgba_to_color(rgba: Iterable[float]) -> Color:
     return rgb_to_color(rgba[:3])
 
 
-@deprecated(replacement="colour.rgb2hex")
 def rgb_to_hex(rgb: Iterable[float]) -> str:
     return "#" + "".join("%02x" % round(255 * x) for x in rgb)
 
 
-@deprecated(replacement="colour.hex2rgb")
 def hex_to_rgb(hex_code: str) -> np.ndarray:
     hex_part = hex_code[1:]
     if len(hex_part) == 3:

--- a/manim/utils/color.py
+++ b/manim/utils/color.py
@@ -21,100 +21,19 @@ __all__ = [
 ]
 
 import random
-import warnings
-from enum import Enum, EnumMeta
+from enum import Enum
 from typing import Iterable
 
 import numpy as np
 from colour import Color, web2rgb
 
 from ..utils.bezier import interpolate
+from ..utils.deprecation import deprecated
 from ..utils.space_ops import normalize
 
 
-class ColorsMeta(EnumMeta):
-    def __getattribute__(self, colorName):
-        colors = [
-            "white",
-            "gray_a",
-            "gray_b",
-            "gray_c",
-            "gray_d",
-            "gray_e",
-            "black",
-            "lighter_gray",
-            "gray",
-            "darker_gray",
-            "blue_a",
-            "blue_b",
-            "blue_c",
-            "blue_d",
-            "blue_e",
-            "pure_blue",
-            "blue",
-            "dark_blue",
-            "teal_a",
-            "teal_b",
-            "teal_c",
-            "teal_d",
-            "teal_e",
-            "teal",
-            "green_a",
-            "green_b",
-            "green_c",
-            "green_d",
-            "green_e",
-            "pure_green",
-            "green",
-            "yellow_a",
-            "yellow_b",
-            "yellow_c",
-            "yellow_d",
-            "yellow_e",
-            "yellow",
-            "gold_a",
-            "gold_b",
-            "gold_c",
-            "gold_d",
-            "gold_e",
-            "gold",
-            "red_a",
-            "red_b",
-            "red_c",
-            "red_d",
-            "red_e",
-            "pure_red",
-            "red",
-            "maroon_a",
-            "maroon_b",
-            "maroon_c",
-            "maroon_d",
-            "maroon_e",
-            "maroon",
-            "purple_a",
-            "purple_b",
-            "purple_c",
-            "purple_d",
-            "purple_e",
-            "purple",
-            "pink",
-            "light_pink",
-            "orange",
-            "light_brown",
-            "dark_brown",
-            "gray_brown",
-        ]
-        if colorName in colors:
-            warnings.warn(
-                "Color enums is deprecated in favor of the constants. "
-                "The constants can be accessed by importing manim.utils.color",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return EnumMeta.__getattribute__(self, colorName)
-
-
-class Colors(Enum, metaclass=ColorsMeta):
+@deprecated(replacement="constants")
+class Colors(Enum):
     """A list of pre-defined colors.
 
     Examples
@@ -619,13 +538,8 @@ __all__ += [
 ]
 
 
+@deprecated(replacement="Color.get_rgb()")
 def color_to_rgb(color: Color | str) -> np.ndarray:
-    warnings.warn(
-        "This method is not guaranteed to stay around. "
-        "Please refer to colour module `Color.get_rgb` for Color to rgb conversion",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if isinstance(color, str):
         return hex_to_rgb(color)
     elif isinstance(color, Color):
@@ -649,23 +563,13 @@ def rgba_to_color(rgba: Iterable[float]) -> Color:
     return rgb_to_color(rgba[:3])
 
 
+@deprecated(replacement="colour.rgb2hex")
 def rgb_to_hex(rgb: Iterable[float]) -> str:
-    warnings.warn(
-        "This method is not guaranteed to stay around. "
-        "Please refer to colour module `rgb2hex` for rgb to hex conversion",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return "#" + "".join("%02x" % round(255 * x) for x in rgb)
 
 
+@deprecated(replacement="colour.hex2rgb")
 def hex_to_rgb(hex_code: str) -> np.ndarray:
-    warnings.warn(
-        "This method is not guaranteed to stay around. "
-        "Please refer to colour module `hex2rgb` for hex to rgb conversion",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     hex_part = hex_code[1:]
     if len(hex_part) == 3:
         hex_part = "".join([2 * c for c in hex_part])


### PR DESCRIPTION
This removes the MetaEnum class as the `deprecated` decorator fills its function. All other warnings in `color.py` is also replaced by the `deprecated` decorator.